### PR TITLE
Use rustdoc-style comments

### DIFF
--- a/player/src/rusty_backend/dynamic_mixer.rs
+++ b/player/src/rusty_backend/dynamic_mixer.rs
@@ -68,19 +68,19 @@ where
 
 /// The output of the mixer. Implements `Source`.
 pub struct DynamicMixer<S> {
-    // The current iterator that produces samples.
+    /// The current iterator that produces samples.
     current_sources: Vec<Box<dyn Source<Item = S> + Send>>,
 
-    // The pending sounds.
+    /// The pending sounds.
     input: Arc<DynamicMixerController<S>>,
 
-    // The number of samples produced so far.
+    /// The number of samples produced so far.
     sample_count: usize,
 
-    // A temporary vec used in start_pending_sources.
+    /// A temporary vec used in start_pending_sources.
     still_pending: Vec<Box<dyn Source<Item = S> + Send>>,
 
-    // A temporary vec used in sum_current_sources.
+    /// A temporary vec used in sum_current_sources.
     still_current: Vec<Box<dyn Source<Item = S> + Send>>,
 }
 
@@ -151,10 +151,10 @@ impl<S> DynamicMixer<S>
 where
     S: Sample + Send + 'static,
 {
-    // Samples from the #next() function are interlaced for each of the channels.
-    // We need to ensure we start playing sources so that their samples are
-    // in-step with the modulo of the samples produced so far. Otherwise, the
-    // sound will play on the wrong channels, e.g. left / right will be reversed.
+    /// Samples from the #next() function are interlaced for each of the channels.
+    /// We need to ensure we start playing sources so that their samples are
+    /// in-step with the modulo of the samples produced so far. Otherwise, the
+    /// sound will play on the wrong channels, e.g. left / right will be reversed.
     fn start_pending_sources(&mut self) {
         let mut pending = self.input.pending_sources.lock().unwrap(); // TODO: relax ordering?
 

--- a/player/src/rusty_backend/queue.rs
+++ b/player/src/rusty_backend/queue.rs
@@ -47,7 +47,7 @@ where
 pub struct SourcesQueueInput<S> {
     next_sounds: Mutex<Vec<(Box<dyn Source<Item = S> + Send>, Option<flume::Sender<()>>)>>,
 
-    // See constructor.
+    /// See constructor.
     keep_alive_if_empty: AtomicBool,
 }
 
@@ -95,13 +95,13 @@ where
 
 /// The output of the queue. Implements `Source`.
 pub struct SourcesQueueOutput<S> {
-    // The current iterator that produces samples.
+    /// The current iterator that produces samples.
     current: Box<dyn Source<Item = S> + Send>,
 
-    // Signal this sender before picking from `next`.
+    /// Signal this sender before picking from `next`.
     signal_after_end: Option<flume::Sender<()>>,
 
-    // The next sounds.
+    /// The next sounds.
     input: Arc<SourcesQueueInput<S>>,
     sample_cache: VecDeque<Option<S>>,
 }
@@ -203,10 +203,10 @@ impl<S> SourcesQueueOutput<S>
 where
     S: Sample + Send + 'static,
 {
-    // Called when `current` is empty and we must jump to the next element.
-    // Returns `Ok` if the sound should continue playing, or an error if it should stop.
-    //
-    // This method is separate so that it is not inlined.
+    /// Called when `current` is empty and we must jump to the next element.
+    /// Returns `Ok` if the sound should continue playing, or an error if it should stop.
+    ///
+    /// This method is separate so that it is not inlined.
     fn go_next(&mut self) -> Result<(), ()> {
         if let Some(signal_after_end) = self.signal_after_end.take() {
             let _ = signal_after_end.send(());

--- a/player/src/rusty_backend/source/periodic.rs
+++ b/player/src/rusty_backend/source/periodic.rs
@@ -26,16 +26,16 @@ where
 #[derive(Clone, Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct PeriodicAccess<I, F> {
-    // The inner source.
+    /// The inner source.
     input: I,
 
-    // Closure that gets access to `inner`.
+    /// Closure that gets access to `inner`.
     modifier: F,
 
-    // The frequency with which local_volume should be updated by remote_volume
+    /// The frequency with which local_volume should be updated by remote_volume
     update_frequency: u32,
 
-    // How many samples remain until it is time to update local_volume with remote_volume.
+    /// How many samples remain until it is time to update local_volume with remote_volume.
     samples_until_update: u32,
 }
 

--- a/player/src/rusty_backend/source/take.rs
+++ b/player/src/rusty_backend/source/take.rs
@@ -56,9 +56,9 @@ pub struct TakeDuration<I> {
     remaining_duration: Duration,
     requested_duration: Duration,
     filter: Option<DurationFilter>,
-    // Remaining samples in current frame.
+    /// Remaining samples in current frame.
     current_frame_len: Option<usize>,
-    // Only updated when the current frame len is exausted.
+    /// Only updated when the current frame len is exausted.
     duration_per_sample: Duration,
 }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -11,20 +11,17 @@ pub use writer::{write, write_video};
 
 use crate::{consts::CACHE_DIR, systems::logger::log_};
 
-// A global variable to store the current musical Database
+/// A global variable to store the current musical Database
 pub static DATABASE: Lazy<RwLock<Vec<Video>>> = Lazy::new(|| RwLock::new(Vec::new()));
 
-/**
- * Remove a video from the database
- */
+/// Remove a video from the database
 pub fn remove_video(video: &Video) {
     let mut database = DATABASE.write().unwrap();
     database.retain(|v| v.video_id != video.video_id);
     write();
 }
-/**
- * append a video to the database
- */
+
+/// Append a video to the database
 pub fn append(video: Video) {
     let mut file = OpenOptions::new()
         .write(true)

--- a/src/database/reader.rs
+++ b/src/database/reader.rs
@@ -5,9 +5,7 @@ use ytpapi::Video;
 
 use crate::consts::CACHE_DIR;
 
-/**
- * Reads the database
- */
+/// Reads the database
 pub fn read() -> Option<Vec<Video>> {
     let mut buffer = Cursor::new(std::fs::read(CACHE_DIR.join("db.bin")).ok()?);
     let mut videos = Vec::new();
@@ -17,9 +15,7 @@ pub fn read() -> Option<Vec<Video>> {
     Some(videos)
 }
 
-/**
- * Reads a video from the cursor
- */
+/// Reads a video from the cursor
 fn read_video(buffer: &mut Cursor<Vec<u8>>) -> Option<Video> {
     Some(Video {
         title: read_str(buffer)?,
@@ -29,18 +25,15 @@ fn read_video(buffer: &mut Cursor<Vec<u8>>) -> Option<Video> {
         duration: read_str(buffer)?,
     })
 }
-/**
- * Reads a string from the cursor
- */
+
+/// Reads a string from the cursor
 fn read_str(cursor: &mut Cursor<Vec<u8>>) -> Option<String> {
     let mut buf = vec![0u8; read_u32(cursor)? as usize];
     cursor.read_exact(&mut buf).ok()?;
     String::from_utf8(buf).ok()
 }
 
-/**
- * Reads a u32 from the cursor
- */
+/// Reads a u32 from the cursor
 fn read_u32(cursor: &mut Cursor<Vec<u8>>) -> Option<u32> {
     ReadVarint::<u32>::read_varint(cursor).ok()
 }

--- a/src/database/writer.rs
+++ b/src/database/writer.rs
@@ -5,9 +5,7 @@ use ytpapi::Video;
 
 use crate::consts::CACHE_DIR;
 
-/**
- * Writes the database to the disk
- */
+/// Writes the database to the disk
 pub fn write() {
     let db = super::DATABASE.read().unwrap();
     let mut file = OpenOptions::new()
@@ -21,9 +19,7 @@ pub fn write() {
     }
 }
 
-/**
- * Writes a video to a file
- */
+/// Writes a video to a file
 pub fn write_video(buffer: &mut impl Write, video: &Video) {
     write_str(buffer, &video.title);
     write_str(buffer, &video.author);
@@ -32,17 +28,13 @@ pub fn write_video(buffer: &mut impl Write, video: &Video) {
     write_str(buffer, &video.duration);
 }
 
-/**
- * Writes a string from the cursor
- */
+/// Writes a string from the cursor
 fn write_str(cursor: &mut impl Write, value: &str) {
     write_u32(cursor, value.len() as u32);
     cursor.write_all(value.as_bytes()).unwrap();
 }
 
-/**
- * Writes a u32 from the cursor
- */
+/// Writes a u32 from the cursor
 fn write_u32(cursor: &mut impl Write, value: u32) {
     cursor.write_varint(value).unwrap();
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,9 +2,7 @@ use flume::Sender;
 
 use crate::term::{ManagerMessage, Screens};
 
-/**
- * Utils to handle errors
- */
+/// Utils to handle errors
 pub fn handle_error_option<T, E>(
     updater: &Sender<ManagerMessage>,
     error_type: &'static str,
@@ -27,9 +25,7 @@ where
     }
 }
 
-/**
- * Utils to handle errors
- */
+/// Utils to handle errors
 pub fn handle_error<T>(updater: &Sender<ManagerMessage>, error_type: &'static str, a: Result<(), T>)
 where
     T: std::fmt::Display,

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -2,5 +2,5 @@ pub mod app_status;
 pub mod media;
 pub mod music_status;
 pub mod music_status_action;
-pub mod sound_action;
 pub mod performance;
+pub mod sound_action;

--- a/src/structures/sound_action.rs
+++ b/src/structures/sound_action.rs
@@ -5,9 +5,7 @@ use crate::{
     systems::player::PlayerState,
 };
 
-/**
- * Actions that can be sent to the player from other services
- */
+/// Actions that can be sent to the player from other services
 #[derive(Debug, Clone)]
 pub enum SoundAction {
     Cleanup,

--- a/src/systems/download.rs
+++ b/src/systems/download.rs
@@ -24,9 +24,7 @@ fn take() -> Option<Video> {
     DOWNLOAD_QUEUE.lock().unwrap().pop_front()
 }
 
-/**
- * A worker of this system that downloads pending songs
- */
+/// A worker of this system that downloads pending songs
 fn spawn_system_worker_instance(s: Arc<Sender<SoundAction>>) {
     HANDLES.lock().unwrap().push(tokio::task::spawn(async move {
         let mut k = true;
@@ -46,9 +44,7 @@ fn spawn_system_worker_instance(s: Arc<Sender<SoundAction>>) {
     }));
 }
 
-/**
- * Destroy all the worker and task getting processed and starts back the system
- */
+/// Destroy all the worker and task getting processed and starts back the system
 pub fn clean(sender: Arc<Sender<SoundAction>>) {
     DOWNLOAD_QUEUE.lock().unwrap().clear();
     {
@@ -63,9 +59,7 @@ pub fn clean(sender: Arc<Sender<SoundAction>>) {
     spawn_system(sender);
 }
 
-/**
- * Append a video to the download queue to be processed by the system
- */
+/// Append a video to the download queue to be processed by the system
 pub fn add(video: Video, s: &Sender<SoundAction>) {
     let download_path_json = CACHE_DIR.join(format!("downloads/{}.json", &video.video_id));
     if download_path_json.exists() {

--- a/src/tasks/clean.rs
+++ b/src/tasks/clean.rs
@@ -1,8 +1,7 @@
 use crate::{consts::CACHE_DIR, structures::performance};
 
-/**
- * This function is called on start to clean the database and the files that are incompletly downloaded due to a crash.
- */
+/// This function is called on start to clean the database and the files
+/// that are incompletely downloaded due to a crash.
 pub fn spawn_clean_task() {
     tokio::task::spawn(async move {
         let guard = performance::guard("Clean task");

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -149,9 +149,8 @@ impl Manager {
         }
         false
     }
-    /**
-     * The main loop of the manager
-     */
+
+    /// The main loop of the manager
     pub fn run(&mut self, updater: &Receiver<ManagerMessage>) -> Result<(), io::Error> {
         // setup terminal
         enable_raw_mode()?;

--- a/ytpapi/src/structs.rs
+++ b/ytpapi/src/structs.rs
@@ -5,17 +5,16 @@ use serde_json::Value;
 
 use crate::Error;
 
-/**
- * Applies recursively the `transformer` function to the given json value and returns the transformed values.
- */
+
+/// Applies recursively the `transformer` function to the given json value
+/// and returns the transformed values.
 pub(crate) fn from_json<T: PartialEq>(
     json: &str,
     transformer: impl Fn(&Value) -> Option<T>,
 ) -> Result<Vec<T>, Error> {
-    /**
-     * Execute a function on each element of a json value recursively.
-     * When the function returns something, the value is added to the result.
-     */
+
+    /// Execute a function on each element of a json value recursively.
+    /// When the function returns something, the value is added to the result.
     pub(crate) fn inner_crawl<T: PartialEq>(
         value: &Value,
         playlists: &mut Vec<T>,
@@ -73,10 +72,9 @@ pub struct Playlist {
     pub browse_id: String,
 }
 
-/**
- * Tries to extract a playlist from a json value.
- * Quite flexible to reduce odds of API change breaking this.
- */
+
+/// Tries to extract a playlist from a json value.
+/// Quite flexible to reduce odds of API change breaking this.
 pub(crate) fn get_playlist(value: &Value) -> Option<Playlist> {
     let object = value.as_object()?;
     let title_text = get_text(object.get("title")?, true)?;
@@ -93,10 +91,9 @@ pub(crate) fn get_playlist(value: &Value) -> Option<Playlist> {
     })
 }
 
-/**
- * Tries to extract the text from a json value.
- * text_clean: Weather to include singleton text.
- */
+
+/// Tries to extract the text from a json value.
+/// text_clean: Weather to include singleton text.
 fn get_text(value: &Value, text_clean: bool) -> Option<String> {
     if let Some(e) = value.as_str() {
         Some(e.to_string())
@@ -124,9 +121,8 @@ fn get_text(value: &Value, text_clean: bool) -> Option<String> {
     }
 }
 
-/**
- * Tries to find a video id in the json
- */
+
+/// Tries to find a video id in the json
 pub fn get_videoid(value: &Value) -> Option<String> {
     match value {
         Value::Array(e) => e.iter().find_map(get_videoid),
@@ -139,10 +135,9 @@ pub fn get_videoid(value: &Value) -> Option<String> {
     }
 }
 
-/**
- * Tries to extract a video from a json value.
- * Quite flexible to reduce odds of API change breaking this.
- */
+
+/// Tries to extract a video from a json value.
+/// Quite flexible to reduce odds of API change breaking this.
 pub(crate) fn get_video(value: &Value) -> Option<Video> {
     // Extract the text part (title, author, album) from a json value.
     let mut texts = value


### PR DESCRIPTION
This makes it so Rustdoc, IDEs and other tools can register the docstrings (it also makes it look more idiomatic). This patch takes the liberty of fixing a couple of typos and doing minor line-wrapping.