### PR TITLE
playlist: fix scrolling direction

### DIFF
--- a/src/term/playlist.rs
+++ b/src/term/playlist.rs
@@ -83,9 +83,9 @@ impl Screen for Chooser {
                     frame_data,
                 );
             }
-        } else if let MouseEventKind::ScrollUp = &mouse_event.kind {
-            self.selected(self.selected.saturating_add(1) as isize);
         } else if let MouseEventKind::ScrollDown = &mouse_event.kind {
+            self.selected(self.selected.saturating_add(1) as isize);
+        } else if let MouseEventKind::ScrollUp = &mouse_event.kind {
             self.selected(self.selected.saturating_sub(1) as isize);
         }
         EventResponse::None


### PR DESCRIPTION
It's inverted compared to a normal mousewheel as well as in the music player.