### PR TITLE
Replace unwrap with .ok for config string

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -114,7 +114,7 @@ impl Config {
             let project_dirs = get_project_dirs()?;
             let config_path = project_dirs.config_dir().join("config.toml");
             let config_string = std::fs::read_to_string(config_path).ok()?;
-            Some(toml::from_str::<Self>(&config_string).unwrap())
+            toml::from_str::<Self>(&config_string).ok()
         };
         opt().unwrap_or_default()
     }


### PR DESCRIPTION
Swaps the unwrap for .ok so that it converts the result to an option which then implicitly replaces the Some that was wrapping the statement and will return Some if there is a valid config and None if not which will be result in the invalid config being treated as the default config.