### PR TITLE
Make = work too for adding to volume

### DIFF
--- a/src/term/music_player.rs
+++ b/src/term/music_player.rs
@@ -158,7 +158,7 @@ impl Screen for PlayerState {
                 }
                 EventResponse::None
             }
-            KeyCode::Char('+') => {
+            KeyCode::Char('+') | KeyCode::Char('=') => {
                 SoundAction::Plus.apply_sound_action(self);
                 EventResponse::None
             }


### PR DESCRIPTION
In most keyboards, People have to hold shift to actually type '+', so to cover that, I put the '=' there to work with other keyboards like mine.