### PR TITLE
prevent console window closing on windows, does nothing on linux

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,8 @@ async fn app_start() {
         println!("Can't read or find `{}`", filepath.display());
         println!("Error: {error}");
         println!("{HEADER_TUTORIAL}");
+        // prevent console window closing on windows, does nothing on linux
+        std::io::stdin().read_line(&mut String::new()).unwrap();
         return;
     }
 


### PR DESCRIPTION
I tested this on windows and it works as expected, unfortunately I can't for the life of me make the program build under WSL2 or inside an Ubuntu VM (I believe the issue with how I'm doing things, and not an issue with this specific project).
Please test that this does not do something weird on Linux when there's no headers.txt file.