### PR TITLE
arg --fix-db won't panic anymore

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -26,8 +26,7 @@ pub static CACHE_DIR: Lazy<PathBuf> = Lazy::new(|| {
 
 pub static CONFIG: Lazy<config::Config> = Lazy::new(config::Config::new);
 
-pub const INTRODUCTION :&str = 
-r#"Usage: ytermusic [options]
+pub const INTRODUCTION: &str = r#"Usage: ytermusic [options]
 
 YTerMusic is a TUI based Youtube Music Player that aims to be as fast and simple as possible.
 In order to get your music, create a file "headers.txt" in the config folder, and copy the Cookie and User-Agent from request header of the music.youtube.com html document "/" page.

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -25,3 +25,34 @@ pub static CACHE_DIR: Lazy<PathBuf> = Lazy::new(|| {
 });
 
 pub static CONFIG: Lazy<config::Config> = Lazy::new(config::Config::new);
+
+pub const INTRODUCTION :&str = 
+r#"Usage: ytermusic [options]
+
+YTerMusic is a TUI based Youtube Music Player that aims to be as fast and simple as possible.
+In order to get your music, create a file "headers.txt" in the config folder, and copy the Cookie and User-Agent from request header of the music.youtube.com html document "/" page.
+More info at: https://github.com/ccgauche/ytermusic
+
+Options:
+        -h or --help        Show this menu
+        --files             Show the location of the ytermusic files
+        --fix-db            Fix the database in cache
+        --clear-cache       Erase all the files in cache
+
+Shortcuts:
+        Use your mouse to click in lists if your terminal has mouse support
+        Space                     play/pause
+        Enter                     select a playlist or a music
+        f                         search
+        s                         shuffle
+        Arrow Right or >          skip 5 seconds
+        Arrow Left or <           go back 5 seconds
+        CTRL + Arrow Right (>)    go to the next song
+        CTRL + Arrow Left  (<)    go to the previous song
+        +                         volume up
+        -                         volume down
+        Arrow down                scroll down
+        Arrow up                  scroll up
+        ESC                       exit the current menu
+        CTRL + C or CTRL + D      quit
+"#;

--- a/src/database/writer.rs
+++ b/src/database/writer.rs
@@ -27,106 +27,103 @@ pub fn fix_db() {
     db.clear();
     let cache_folder = CACHE_DIR.join("downloads");
     if !cache_folder.is_dir() {
-        println!("[WARN] No download directory found in Cache",);
+        println!(
+            "[WARN] The download folder in the cache wasn't found ({:?})",
+            cache_folder
+        );
+        return;
     }
-    else {
-        for entry in std::fs::read_dir(&cache_folder).unwrap() {
-            let entry = entry.unwrap();
-            let path = entry.path();
-            // Check if the file is a json file (+ sloppy check if there is any files or directory)
-            if let Some(ext) = path.extension() {
-                if ext.to_str().unwrap_or("") != "json" {
-                    continue;
-                }
-            }
-            else {
-                continue;
-            }
-            // Read the file if not readable do not add it to the database
-            let content = match std::fs::read_to_string(&path) {
-                Ok(content) => content,
-                Err(e) => {
-                    match std::fs::remove_file(&path){
-                        Ok(_) => println!(
-                            "[INFO] Removing file {:?} because the file is not readable: {e:?}",
-                            path.file_name()
-                        ),
-                        Err(ef) => println!(
-                            "[ERROR] file {:?} is not readable: {e:?}, but could not be deleted: {ef:?}",
-                            path.file_name()
-                        ),
-                    }
-                    continue;
-                }
-            };
-            // Check if the file is a valid json file
-            let video = match serde_json::from_str::<YoutubeMusicVideoRef>(&content) {
-                Ok(parsed) => parsed,
-                Err(e) => {
-                    match std::fs::remove_file(&path){
-                        Ok(_) => println!(
-                            "[INFO] Removing file {:?} because the file is not a valid json file: {e:?}",
-                            path.file_name()
-                        ),
-                        Err(ef) => println!(
-                            "[ERROR] file {:?} is not a valid json file: {e:?}, but could not be deleted: {ef:?}",
-                            path.file_name()
-                        ),
-                    }
-                    continue;
-                }
-            };
-            // Check if the video file exists
-            let video_file = cache_folder.join(format!("{}.mp4", video.video_id));
-            if !video_file.exists() {
-                match std::fs::remove_file(&path){
-                    Ok(_) => println!(
-                        "[INFO] Removing file {:?} because the video file does not exist",
-                        path.file_name()
-                    ),
-                    Err(ef) => println!(
-                        "[ERROR] video assocated to file {:?} does not exist, but the file could not be deleted: {ef:?}",
-                        path.file_name()
-                    ),
-                }
-                continue;
-            }
-            // Read the video file
-            let video_file = match std::fs::read(&video_file) {
-                Ok(video_file) => video_file,
-                Err(e) => {
-                    match std::fs::remove_file(&path){
-                        Ok(_) => println!(
-                            "[INFO] Removing file {:?} because the video file is not readable: {e:?}",
-                            path.file_name()
-                        ),
-                        Err(ef) => println!(
-                            "[ERROR] video associated to file {:?} is not readable: {e:?}, but the file could not be deleted: {ef:?}",
-                            path.file_name()
-                        ),
-                    }
-                    continue;
-                }
-            };
-            // Check if the video file contains the header
-            if !video_file.starts_with(&[
-                0, 0, 0, 24, 102, 116, 121, 112, 100, 97, 115, 104, 0, 0, 0, 0,
-            ]) {
-                match std::fs::remove_file(&path){
-                    Ok(_) => println!(
-                        "[INFO] Removing file {:?} because the video file does not contain the header",
-                        path.file_name()
-                    ),
-                    Err(ef) => println!(
-                        "[ERROR] video associated to file {:?} does not contain the header, but the file could not be deleted: {ef:?}",
-                        path.file_name()
-                    ),
-                }
-                continue;
-            }
-            db.push(video);
+    for entry in std::fs::read_dir(&cache_folder).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        // Check if the file is a json file (+ sloppy check if there is any files or directory)
+        if path.extension().unwrap_or_default() != "json" {
+            continue;
         }
-    };
+        // Read the file if not readable do not add it to the database
+        let content = match std::fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(e) => {
+                match std::fs::remove_file(&path){
+                    Ok(_) => println!(
+                        "[INFO] Removing file {:?} because the file is not readable: {e:?}",
+                        path.file_name()
+                    ),
+                    Err(ef) => println!(
+                        "[ERROR] file {:?} is not readable: {e:?}, but could not be deleted: {ef:?}",
+                        path.file_name()
+                    ),
+                }
+                continue;
+            }
+        };
+        // Check if the file is a valid json file
+        let video = match serde_json::from_str::<YoutubeMusicVideoRef>(&content) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                match std::fs::remove_file(&path){
+                    Ok(_) => println!(
+                        "[INFO] Removing file {:?} because the file is not a valid json file: {e:?}",
+                        path.file_name()
+                    ),
+                    Err(ef) => println!(
+                        "[ERROR] file {:?} is not a valid json file: {e:?}, but could not be deleted: {ef:?}",
+                        path.file_name()
+                    ),
+                }
+                continue;
+            }
+        };
+        // Check if the video file exists
+        let video_file = cache_folder.join(format!("{}.mp4", video.video_id));
+        if !video_file.exists() {
+            match std::fs::remove_file(&path){
+                Ok(_) => println!(
+                    "[INFO] Removing file {:?} because the video file does not exist",
+                    path.file_name()
+                ),
+                Err(ef) => println!(
+                    "[ERROR] video assocated to file {:?} does not exist, but the file could not be deleted: {ef:?}",
+                    path.file_name()
+                ),
+            }
+            continue;
+        }
+        // Read the video file
+        let video_file = match std::fs::read(&video_file) {
+            Ok(video_file) => video_file,
+            Err(e) => {
+                match std::fs::remove_file(&path){
+                    Ok(_) => println!(
+                        "[INFO] Removing file {:?} because the video file is not readable: {e:?}",
+                        path.file_name()
+                    ),
+                    Err(ef) => println!(
+                        "[ERROR] video associated to file {:?} is not readable: {e:?}, but the file could not be deleted: {ef:?}",
+                        path.file_name()
+                    ),
+                }
+                continue;
+            }
+        };
+        // Check if the video file contains the header
+        if !video_file.starts_with(&[
+            0, 0, 0, 24, 102, 116, 121, 112, 100, 97, 115, 104, 0, 0, 0, 0,
+        ]) {
+            match std::fs::remove_file(&path){
+                Ok(_) => println!(
+                    "[INFO] Removing file {:?} because the video file does not contain the header",
+                    path.file_name()
+                ),
+                Err(ef) => println!(
+                    "[ERROR] video associated to file {:?} does not contain the header, but the file could not be deleted: {ef:?}",
+                    path.file_name()
+                ),
+            }
+            continue;
+        }
+        db.push(video);
+    }
 }
 
 /// Writes a video to a file

--- a/src/database/writer.rs
+++ b/src/database/writer.rs
@@ -26,69 +26,80 @@ pub fn fix_db() {
     let mut db = DATABASE.write().unwrap();
     db.clear();
     let cache_folder = CACHE_DIR.join("downloads");
-    for entry in std::fs::read_dir(&cache_folder).unwrap() {
-        let entry = entry.unwrap();
-        let path = entry.path();
-        // Check if the file is a json file
-        if path.extension().unwrap() != "json" {
-            continue;
-        }
-        // Read the file if not readable do not add it to the database
-        let content = match std::fs::read_to_string(&path) {
-            Ok(content) => content,
-            Err(e) => {
-                println!(
-                    "[INFO] Removing file {:?} because the file is not readable: {e:?}",
-                    path.file_name()
-                );
-                continue;
-            }
-        };
-        // Check if the file is a valid json file
-        let video = match serde_json::from_str::<YoutubeMusicVideoRef>(&content) {
-            Ok(parsed) => parsed,
-            Err(e) => {
-                println!(
-                    "[INFO] Removing file {:?} because the file is not a valid json file: {e:?}",
-                    path.file_name()
-                );
-                continue;
-            }
-        };
-        // Check if the video file exists
-        let video_file = cache_folder.join(format!("{}.mp4", video.video_id));
-        if !video_file.exists() {
-            println!(
-                "[INFO] Removing file {:?} because the video file does not exist",
-                path.file_name()
-            );
-            continue;
-        }
-        // Read the video file
-        let video_file = match std::fs::read(&video_file) {
-            Ok(video_file) => video_file,
-            Err(e) => {
-                println!(
-                    "[INFO] Removing file {:?} because the video file is not readable: {e:?}",
-                    path.file_name()
-                );
-                continue;
-            }
-        };
-        // Check if the video file contains the header
-        if !video_file.starts_with(&[
-            0, 0, 0, 24, 102, 116, 121, 112, 100, 97, 115, 104, 0, 0, 0, 0,
-        ]) {
-            println!(
-                "[INFO] Removing file {:?} because the video file does not contain the header",
-                path.file_name()
-            );
-            continue;
-        }
-
-        db.push(video);
+    if !cache_folder.is_dir() {
+        println!("[WARN] No download directory found in Cache",);
     }
+    else {
+        for entry in std::fs::read_dir(&cache_folder).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            // Check if the file is a json file (+ sloppy check if there is any files or directory)
+            if let Some(ext) = path.extension() {
+                if ext.to_str().unwrap_or("") != "json" {
+                    continue;
+                }
+            }
+            else {
+                continue;
+            }
+            // Read the file if not readable do not add it to the database
+            let content = match std::fs::read_to_string(&path) {
+                Ok(content) => content,
+                Err(e) => {
+                    println!(
+                        "[INFO] Removing file {:?} because the file is not readable: {e:?}",
+                        path.file_name()
+                    );
+                    continue;
+                }
+            };
+            // Check if the file is a valid json file
+            let video = match serde_json::from_str::<YoutubeMusicVideoRef>(&content) {
+                Ok(parsed) => parsed,
+                Err(e) => {
+                    println!(
+                        "[INFO] Removing file {:?} because the file is not a valid json file: {e:?}",
+                        path.file_name()
+                    );
+                    continue;
+                }
+            };
+            // Check if the video file exists
+            let video_file = cache_folder.join(format!("{}.mp4", video.video_id));
+            if !video_file.exists() {
+                println!(
+                    "[INFO] Removing file {:?} because the video file does not exist",
+                    path.file_name()
+                );
+                continue;
+            }
+            // Read the video file
+            let video_file = match std::fs::read(&video_file) {
+                Ok(video_file) => video_file,
+                Err(e) => {
+                    println!(
+                        "[INFO] Removing file {:?} because the video file is not readable: {e:?}",
+                        path.file_name()
+                    );
+                    continue;
+                }
+            };
+            // Check if the video file contains the header
+            if !video_file.starts_with(&[
+                0, 0, 0, 24, 102, 116, 121, 112, 100, 97, 115, 104, 0, 0, 0, 0,
+            ]) {
+                println!(
+                    "[INFO] Removing file {:?} because the video file does not contain the header",
+                    path.file_name()
+                );
+                continue;
+            }
+            db.push(video);
+        }
+    };
+        
 }
+// TODO : really fix the db (delete bad files and rewrite the db.bin)
 
 /// Writes a video to a file
 pub fn write_video(buffer: &mut impl Write, video: &YoutubeMusicVideoRef) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,7 @@ async fn main() {
                 println!("Unknown argument `{e}`");
                 println!("Here are the available arguments:");
                 println!(" - --files: Show the location of the ytermusic files");
+                println!(" - --clear-cache: Erase all the files in cache");
                 println!(" - --fix-db: Fix the database");
                 return;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,35 +1,4 @@
-const INTRODUCTION :&str = 
-r#"Usage: ytermusic [options]
-
-YTerMusic is a TUI based Youtube Music Player that aims to be as fast and simple as possible.
-In order to get your music, create a file "headers.txt" in the config folder, and copy the Cookie and User-Agent from request header of the music.youtube.com html document "/" page.
-More info at: https://github.com/ccgauche/ytermusic
-
-Options:
-        -h or --help        Show this menu
-        --files             Show the location of the ytermusic files
-        --fix-db            Fix the database in cache
-        --clear-cache       Erase all the files in cache
-
-Shortcuts:
-        Use your mouse to click in lists if your terminal has mouse support
-        Space                     play/pause
-        Enter                     select a playlist or a music
-        f                         search
-        s                         shuffle
-        Arrow Right or >          skip 5 seconds
-        Arrow Left or <           go back 5 seconds
-        CTRL + Arrow Right (>)    go to the next song
-        CTRL + Arrow Left  (<)    go to the previous song
-        +                         volume up
-        -                         volume down
-        Arrow down                scroll down
-        Arrow up                  scroll up
-        ESC                       exit the current menu
-        CTRL + C or CTRL + D      quit
-"#;
-
-use consts::CACHE_DIR;
+use consts::{CACHE_DIR, INTRODUCTION};
 use flume::{Receiver, Sender};
 use log::{error, info};
 use once_cell::sync::Lazy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,34 @@
+const INTRODUCTION :&str = 
+r#"Usage: ytermusic [options]
+
+YTerMusic is a TUI based Youtube Music Player that aims to be as fast and simple as possible.
+In order to get your music, create a file "headers.txt" in the config folder, and copy the Cookie and User-Agent from request header of the music.youtube.com html document "/" page.
+More info at: https://github.com/ccgauche/ytermusic
+
+Options:
+        -h or --help        Show this menu
+        --files             Show the location of the ytermusic files
+        --fix-db            Fix the database in cache
+        --clear-cache       Erase all the files in cache
+
+Shortcuts:
+        Use your mouse to click in lists if your terminal has mouse support
+        Space                     play/pause
+        Enter                     select a playlist or a music
+        f                         search
+        s                         shuffle
+        Arrow Right or >          skip 5 seconds
+        Arrow Left or <           go back 5 seconds
+        CTRL + Arrow Right (>)    go to the next song
+        CTRL + Arrow Left  (<)    go to the previous song
+        +                         volume up
+        -                         volume down
+        Arrow down                scroll down
+        Arrow up                  scroll up
+        ESC                       exit the current menu
+        CTRL + C or CTRL + D      quit
+"#;
+
 use consts::CACHE_DIR;
 use flume::{Receiver, Sender};
 use log::{error, info};
@@ -70,6 +101,10 @@ async fn main() {
     // Check if the first param is --files
     if let Some(arg) = std::env::args().nth(1) {
         match arg.as_str() {
+            "-h" | "--help" =>{
+                println!("{}", INTRODUCTION);
+                return;
+            }
             "--files" => {
                 println!("# Location of ytermusic files");
                 println!(" - Logs: {}", get_log_file_path().display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn main() {
     // Check if the first param is --files
     if let Some(arg) = std::env::args().nth(1) {
         match arg.as_str() {
-            "-h" | "--help" =>{
+            "-h" | "--help" => {
                 println!("{}", INTRODUCTION);
                 return;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ async fn main() {
             }
             "--fix-db" => {
                 database::fix_db();
+                database::write();
                 println!("[INFO] Database fixed");
                 return;
             }

--- a/src/tasks/clean.rs
+++ b/src/tasks/clean.rs
@@ -7,7 +7,7 @@ pub fn spawn_clean_task() {
         let guard = performance::guard("Clean task");
         for i in std::fs::read_dir(CACHE_DIR.join("downloads")).unwrap() {
             let path = i.unwrap().path();
-            if path.ends_with(".mp4") {
+            if path.extension().unwrap_or_default() == "mp4" {
                 let mut path1 = path.clone();
                 path1.set_extension("json");
                 if !path1.exists() {

--- a/src/term/search.rs
+++ b/src/term/search.rs
@@ -10,10 +10,14 @@ use ratatui::{
     Frame,
 };
 use tokio::task::JoinHandle;
-use ytpapi2::{HeaderMap, HeaderValue, SearchResults, YoutubeMusicInstance, YoutubeMusicPlaylistRef, YoutubeMusicVideoRef};
+use ytpapi2::{
+    HeaderMap, HeaderValue, SearchResults, YoutubeMusicInstance, YoutubeMusicPlaylistRef,
+    YoutubeMusicVideoRef,
+};
 
 use crate::{
-    consts::CONFIG, get_header_file, run_service, structures::sound_action::SoundAction, tasks, try_get_cookies, utils::invert, DATABASE
+    consts::CONFIG, get_header_file, run_service, structures::sound_action::SoundAction, tasks,
+    try_get_cookies, utils::invert, DATABASE,
 };
 
 use super::{


### PR DESCRIPTION
...due to missing directory or unexpected files.

- Idiot-proofing the use of --clear-cache before --fix-db (cause I am one)
-  --fix-db does not panic anymore if a file has no extensions according to the extension() method. Happened to me with the .directory files that uses the dolphin file explorer.
-  added a description for --clear-cache if an invalid argument is given. (adding a -h argument could be nice too?)

However --fix-db does not lauch the TUI after being done, nor it removes any of the faulty json or mp4 files, which option seems best?

I quite like this project, as it has all the base features I want for a YTmusic player. So I eventually decided to contribute even if I'm a newcomer to rust.
I will try to work on #93 and/or #88  on my spare time, because I need that the most.