### PR TITLE
Fix brand account support by adding X-Goog-AuthUser header

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,16 @@ YTerMusic is a TUI based Youtube Music Player that aims to be as fast and simple
 - If you use a second account for youtube music
   	1. Go to https://myaccount.google.com/
   	2. Switch to your brand account
-  	3. copy the number written in the url, after \b\
-  	4. paste it into a new `account_id.txt` file in the same folder as `headers.txt`
+  	3. Copy the number written in the url, after `\b\`
+  	4. Paste it into a new `account_id.txt` file in the same folder as `headers.txt`
+  	5. Add the `X-Goog-AuthUser` header to your `headers.txt` file:
+  	   - In the browser developer tools Network tab, find the `X-Goog-AuthUser` header value (usually `0` or `1`)
+  	   - Add it to your `headers.txt`:
+  	   ```
+  	   Cookie: <cookie>
+  	   User-Agent: Mozilla/5.0 (X11; Linux x86_64) ...
+  	   X-Goog-AuthUser: 0
+  	   ```
 
 ## Building from source
 

--- a/crates/ytermusic/src/term/search.rs
+++ b/crates/ytermusic/src/term/search.rs
@@ -236,7 +236,7 @@ impl Search {
                     "user-agent",
                     HeaderValue::from_static("Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"),
                 );
-                YoutubeMusicInstance::new(headermap, None).await    //don't think we need a brand account for search
+                YoutubeMusicInstance::new(headermap, None, None).await    //don't think we need a brand account for search
             } else {
                 YoutubeMusicInstance::from_header_file(get_header_file().unwrap().1.as_path()).await
             }


### PR DESCRIPTION
Hi, found an issue when using a brand account where no playlists would show up. Removing the account_id (i.e. going back to the main account) worked fine however.

After some digging it turns out we're missing a header. This PR just adds support for passing that header through. Have tested this locally and brand accounts work correctly for me now.

## Summary

- Fixes brand account playlists not showing up by adding the required `X-Goog-AuthUser` header to API requests
- Adds `auth_user` field to `YoutubeMusicInstance` struct
- Reads `X-Goog-AuthUser` from `headers.txt` in `from_header_file()`
- Includes header in `browse_raw` and `browse_continuation_raw` API requests
- Updates README with documentation for brand account setup

## Test plan

- [x] Tested with brand account - playlists now load correctly
- [x] Verified backward compatibility - works without `X-Goog-AuthUser` header for non-brand accounts

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)