### PR TITLE
fix: block until shutdown

### DIFF
--- a/crates/ytermusic/src/structures/media.rs
+++ b/crates/ytermusic/src/structures/media.rs
@@ -167,7 +167,9 @@ pub fn run_window_handler(_updater: &Sender<ManagerMessage>) -> Option<()> {
     use crate::is_shutdown_sent;
 
     loop {
-        if crate::shutdown::block_until_shutdown() && is_shutdown_sent() {
+        if !is_shutdown_sent() {
+            crate::shutdown::block_until_shutdown()
+        } else {
             use std::process::exit;
 
             info!("event loop closed");


### PR DESCRIPTION
When updating ytermusic I saw a huge spike in cpu usage (from 0.2 % to 100 % CPU core usage).
I used samply for profiling and saw that most of it was because of the loop checking if the shutdown signal have been sent.
I wanted to return to an async function but I did not want to break the macOS `run_window_handler` and I assume that it is made that way for a reason.
Instead of refactoring everything again, I just placed 100ms sleep into the loop, which I think is a reasonable time for a shutdown procedure.
This is not perfect, but with that we obtain a similar performance than before.

EDIT: I've just noticed that should close issue #132 .