### PR TITLE
feat: add RTL text support for Hebrew/Arabic in TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6236,6 +6236,7 @@ dependencies = [
  "souvlaki",
  "tokio",
  "toml",
+ "unicode-bidi",
  "urlencoding",
  "varuint",
  "winit",

--- a/crates/ytermusic/Cargo.toml
+++ b/crates/ytermusic/Cargo.toml
@@ -26,6 +26,7 @@ varuint = "0.7.1"
 #  --- UI ---
 crossterm = "0.27.0"
 ratatui = { version = "0.26.1", features = ["serde"] }
+unicode-bidi = "0.3"
 
 #  --- Player ---
 player.workspace = true

--- a/crates/ytermusic/src/term/music_player.rs
+++ b/crates/ytermusic/src/term/music_player.rs
@@ -11,7 +11,7 @@ use crate::{
         sound_action::SoundAction,
     },
     systems::{player::PlayerState, DOWNLOAD_MANAGER},
-    utils::invert,
+    utils::{invert, to_bidi_string},
 };
 
 use super::{
@@ -201,7 +201,7 @@ impl Screen for PlayerState {
                     Block::default()
                         .title(
                             self.current()
-                                .map(|x| format!(" {x} "))
+                                .map(|x| format!(" {} ", to_bidi_string(&x.to_string())))
                                 .unwrap_or_else(|| " No music playing ".to_owned()),
                         )
                         .borders(Borders::ALL),
@@ -246,7 +246,11 @@ impl Screen for PlayerState {
                         music_state.style(None)
                     },
                     if let Some(e) = self.list.get(index) {
-                        format!(" {music_state_c} {} | {}", e.author, e.title)
+                        format!(
+                            " {music_state_c} {} | {}",
+                            to_bidi_string(&e.author),
+                            to_bidi_string(&e.title)
+                        )
                     } else {
                         String::new()
                     },

--- a/crates/ytermusic/src/term/playlist.rs
+++ b/crates/ytermusic/src/term/playlist.rs
@@ -9,7 +9,7 @@ use crate::{
     consts::{CACHE_DIR, CONFIG},
     structures::sound_action::{download_manager_handler, SoundAction},
     systems::DOWNLOAD_MANAGER,
-    utils::invert,
+    utils::{invert, to_bidi_string},
     ShutdownSignal, DATABASE,
 };
 
@@ -67,7 +67,7 @@ pub fn format_playlist(name: &str, videos: &[YoutubeMusicVideoRef]) -> String {
         .count();
     format!(
         "{}     ({}/{} {}%)",
-        name,
+        to_bidi_string(name),
         local_videos,
         videos.len(),
         (local_videos as f32 / videos.len() as f32 * 100.0) as u8

--- a/crates/ytermusic/src/term/playlist_view.rs
+++ b/crates/ytermusic/src/term/playlist_view.rs
@@ -3,7 +3,12 @@ use flume::Sender;
 use ratatui::{layout::Rect, style::Style, Frame};
 use ytpapi2::YoutubeMusicVideoRef;
 
-use crate::{consts::CONFIG, structures::sound_action::SoundAction, utils::invert, DATABASE};
+use crate::{
+    consts::CONFIG,
+    structures::sound_action::SoundAction,
+    utils::{invert, to_bidi_string},
+    DATABASE,
+};
 
 use super::{
     item_list::{ListItem, ListItemAction},
@@ -74,7 +79,8 @@ impl Screen for PlaylistView {
     fn handle_global_message(&mut self, m: ManagerMessage) -> EventResponse {
         match m {
             ManagerMessage::Inspect(a, screen, m) => {
-                self.items.set_title(format!(" Inspecting {a} "));
+                self.items
+                    .set_title(format!(" Inspecting {} ", to_bidi_string(&a)));
                 self.goto = screen;
                 let db = DATABASE.read().unwrap();
                 self.items.update(
@@ -82,7 +88,7 @@ impl Screen for PlaylistView {
                         .enumerate()
                         .map(|(i, m)| {
                             (
-                                format!("  {m}"),
+                                format!("  {}", to_bidi_string(&m.to_string())),
                                 PlayListAction(i, !db.iter().any(|x| x.video_id == m.video_id)),
                             )
                         })

--- a/crates/ytermusic/src/term/search.rs
+++ b/crates/ytermusic/src/term/search.rs
@@ -21,7 +21,7 @@ use crate::{
     structures::sound_action::{download_manager_handler, SoundAction},
     systems::DOWNLOAD_MANAGER,
     try_get_cookies,
-    utils::invert,
+    utils::{invert, to_bidi_string},
     ShutdownSignal, DATABASE,
 };
 
@@ -114,7 +114,12 @@ impl Screen for Search {
                 x.title.to_lowercase().contains(&text) || x.author.to_lowercase().contains(&text)
             })
             .cloned()
-            .map(|video| (format!(" {video} "), Status::Local(video)))
+            .map(|video| {
+                (
+                    format!(" {} ", to_bidi_string(&video.to_string())),
+                    Status::Local(video),
+                )
+            })
             .take(100)
             .collect::<Vec<_>>();
         self.list.write().unwrap().update_contents(local.clone());
@@ -137,7 +142,7 @@ impl Screen for Search {
                         for video in e.into_iter() {
                             let id = video.video_id.clone();
                             item.push((
-                                format!(" {video} "),
+                                format!(" {} ", to_bidi_string(&video.to_string())),
                                 if DATABASE.read().unwrap().iter().any(|x| x.video_id == id) {
                                     Status::Local(video)
                                 } else {
@@ -158,7 +163,8 @@ impl Screen for Search {
                                             format_playlist(
                                                 &format!(
                                                     " [P] {} ({})",
-                                                    playlist.name, playlist.subtitle
+                                                    to_bidi_string(&playlist.name),
+                                                    to_bidi_string(&playlist.subtitle)
                                                 ),
                                                 &e,
                                             ),


### PR DESCRIPTION
Before:

<img width="1153" height="450" alt="image" src="https://github.com/user-attachments/assets/912e1990-bc5f-4d3f-87ee-956d7a5ca429" />

After:
<img width="1153" height="450" alt="image" src="https://github.com/user-attachments/assets/06ae94d0-47d9-4d72-b8fa-643a711ab9b5" />


- closes #136
- adopts the code from
  https://github.com/aome510/spotify-player/pull/760 which achieved the
- Apply Unicode Bidirectional Algorithm via unicode-bidi crate to reorder
  RTL text (Hebrew, Arabic) for correct terminal display.
- Add calls to to_bidi_string() utility and applies it at all
  user-facing rendering points: music player title/playlist,
  search results, playlist chooser, and playlist inspector.
