### PR TITLE
fix 403s - swap rusty_ytdl for yt-dlp

### DIFF
--- a/crates/download-manager/Cargo.toml
+++ b/crates/download-manager/Cargo.toml
@@ -7,13 +7,10 @@ edition = "2024"
 ytpapi2.workspace = true
 flume = "0.11.0"
 once_cell = "1.19.0"
-tokio = { version = "1.36.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.36.0", features = ["rt-multi-thread", "process"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 database.workspace = true
 common-structs.workspace = true
-
-#  --- YT Download ---
-rusty_ytdl = { git = "https://github.com/Mithronn/rusty_ytdl/", branch = "main", features = ["rustls", "search", "live"], default-features = false}
 
 log = "0.4.20"

--- a/crates/download-manager/Cargo.toml
+++ b/crates/download-manager/Cargo.toml
@@ -14,3 +14,9 @@ database.workspace = true
 common-structs.workspace = true
 
 log = "0.4.20"
+
+#  --- YT Download ---
+rusty_ytdl = { git = "https://github.com/Mithronn/rusty_ytdl/", branch = "main", features = ["rustls", "search", "live"], default-features = false, optional = true }
+
+[features]
+rusty-ytdl-backend = ["dep:rusty_ytdl"]

--- a/crates/download-manager/src/lib.rs
+++ b/crates/download-manager/src/lib.rs
@@ -19,10 +19,18 @@ pub enum DownloadManagerMessage {
     VideoStatusUpdate(String, MusicDownloadStatus),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Downloader {
+    YtDlp,
+    #[cfg(feature = "rusty-ytdl-backend")]
+    RustyYtdl,
+}
+
 pub struct DownloadManager {
     database: &'static YTLocalDatabase,
     cache_dir: PathBuf,
     parallel_downloads: u16,
+    pub downloader: Downloader,
     handles: Mutex<Vec<JoinHandle<()>>>,
     download_list: Mutex<VecDeque<YoutubeMusicVideoRef>>,
     in_download: Mutex<HashSet<String>>,
@@ -33,11 +41,13 @@ impl DownloadManager {
         cache_dir: PathBuf,
         database: &'static YTLocalDatabase,
         parallel_downloads: u16,
+        downloader: Downloader,
     ) -> Self {
         Self {
             database,
             cache_dir,
             parallel_downloads,
+            downloader,
             handles: Mutex::new(Vec::new()),
             download_list: Mutex::new(VecDeque::new()),
             in_download: Mutex::new(HashSet::new()),

--- a/crates/download-manager/src/task.rs
+++ b/crates/download-manager/src/task.rs
@@ -1,91 +1,82 @@
-use std::sync::Arc;
+use std::process::Stdio;
 
 use log::error;
-use rusty_ytdl::{
-    DownloadOptions, Video, VideoError, VideoOptions, VideoQuality, VideoSearchOptions,
-};
-use tokio::select;
+use tokio::process::Command;
 use ytpapi2::YoutubeMusicVideoRef;
 
 use crate::{DownloadManager, DownloadManagerMessage, MessageHandler, MusicDownloadStatus};
 
-fn new_video_with_id(id: &str) -> Result<Video<'_>, VideoError> {
-    let search_options = VideoSearchOptions::Custom(Arc::new(|format| {
-        format.has_audio && !format.has_video && format.mime_type.container == "mp4"
-    }));
-    let video_options = VideoOptions {
-        quality: VideoQuality::Custom(
-            search_options.clone(),
-            Arc::new(|x, y| x.audio_bitrate.cmp(&y.audio_bitrate)),
-        ),
-        filter: search_options,
-        download_options: DownloadOptions {
-            dl_chunk_size: Some(1024 * 100_u64),
-        },
-        ..Default::default()
-    };
-
-    Video::new_with_options(id, video_options)
+#[derive(Debug)]
+pub enum DownloadError {
+    YtDlpFailed(String),
+    IoError(std::io::Error),
 }
 
-pub async fn download<P: AsRef<std::path::Path>>(
-    video: &Video<'_>,
-    path: P,
-    sender: MessageHandler,
-) -> Result<(), VideoError> {
-    use std::io::Write;
-    let stream = video.stream().await?;
+impl std::fmt::Display for DownloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DownloadError::YtDlpFailed(msg) => write!(f, "yt-dlp failed: {}", msg),
+            DownloadError::IoError(e) => write!(f, "IO error: {}", e),
+        }
+    }
+}
 
-    let length = stream.content_length();
+impl From<std::io::Error> for DownloadError {
+    fn from(e: std::io::Error) -> Self {
+        DownloadError::IoError(e)
+    }
+}
 
-    let mut file =
-        std::fs::File::create(&path).map_err(|e| VideoError::DownloadError(e.to_string()))?;
+async fn download_with_ytdlp(
+    video_id: &str,
+    output_path: &std::path::Path,
+    sender: &MessageHandler,
+) -> Result<(), DownloadError> {
+    sender(DownloadManagerMessage::VideoStatusUpdate(
+        video_id.to_string(),
+        MusicDownloadStatus::Downloading(0),
+    ));
 
-    let mut total = 0;
-    while let Some(chunk) = stream.chunk().await? {
-        total += chunk.len();
+    let url = format!("https://www.youtube.com/watch?v={}", video_id);
 
-        sender(DownloadManagerMessage::VideoStatusUpdate(
-            video.get_video_id(),
-            MusicDownloadStatus::Downloading((total as f64 / length as f64 * 100.0) as usize),
-        ));
+    let output = Command::new("yt-dlp")
+        .args([
+            "--no-playlist",
+            "-f", "bestaudio[ext=m4a]/bestaudio[ext=mp4]/bestaudio",
+            "--merge-output-format", "mp4",
+            "-o", output_path.to_str().unwrap(),
+            "--no-progress",
+            "--quiet",
+            &url,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
 
-        file.write_all(&chunk)
-            .map_err(|e| VideoError::DownloadError(e.to_string()))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(DownloadError::YtDlpFailed(stderr));
     }
 
-    file.flush()
-        .map_err(|e| VideoError::DownloadError(e.to_string()))?;
-
-    if total != length || length == 0 {
-        std::fs::remove_file(path).map_err(|e| VideoError::DownloadError(e.to_string()))?;
-        return Err(VideoError::DownloadError(format!(
-            "Downloaded file is not the same size as the content length ({}/{})",
-            total, length
-        )));
-    }
+    sender(DownloadManagerMessage::VideoStatusUpdate(
+        video_id.to_string(),
+        MusicDownloadStatus::Downloading(100),
+    ));
 
     Ok(())
 }
 
 impl DownloadManager {
-    async fn handle_download(&self, id: &str, sender: MessageHandler) -> Result<(), VideoError> {
-        let idc = id.to_string();
-
-        let video = new_video_with_id(id)?;
-
-        sender(DownloadManagerMessage::VideoStatusUpdate(
-            idc.clone(),
-            MusicDownloadStatus::Downloading(0),
-        ));
+    async fn handle_download(
+        &self,
+        id: &str,
+        sender: MessageHandler,
+    ) -> Result<(), DownloadError> {
         let file = self.cache_dir.join("downloads").join(format!("{id}.mp4"));
-        download(&video, file, sender.clone()).await?;
-        sender(DownloadManagerMessage::VideoStatusUpdate(
-            idc.clone(),
-            MusicDownloadStatus::Downloading(100),
-        ));
-        Ok(())
+        download_with_ytdlp(id, &file, &sender).await
     }
+
     pub async fn start_download(&self, song: YoutubeMusicVideoRef, s: MessageHandler) -> bool {
         {
             let mut downloads = self.in_download.lock().unwrap();
@@ -149,26 +140,11 @@ impl DownloadManager {
             self.start_download(song, s).await;
         };
         let service = tokio::task::spawn(async move {
-            select! {
+            tokio::select! {
                 _ = fut => {},
                 _ = cancelation => {},
             }
         });
         self.handles.lock().unwrap().push(service);
-    }
-}
-
-#[tokio::test]
-async fn video_download_test() {
-    let ids = vec!["iFbNzVFgjCk", "ni-xbEK271I"]; //second not working, need checking
-    for id in ids {
-        let video = Video::new(id).unwrap();
-        let stream = video.stream().await.unwrap();
-        let content_length = stream.content_length();
-        let mut total = 0;
-        while let Some(chunk) = stream.chunk().await.unwrap() {
-            total += chunk.len();
-        }
-        assert_eq!(total, content_length);
     }
 }

--- a/crates/download-manager/src/task.rs
+++ b/crates/download-manager/src/task.rs
@@ -4,7 +4,9 @@ use log::error;
 use tokio::process::Command;
 use ytpapi2::YoutubeMusicVideoRef;
 
-use crate::{Downloader, DownloadManager, DownloadManagerMessage, MessageHandler, MusicDownloadStatus};
+use crate::{
+    DownloadManager, DownloadManagerMessage, Downloader, MessageHandler, MusicDownloadStatus,
+};
 
 #[derive(Debug)]
 pub enum DownloadError {
@@ -53,9 +55,12 @@ async fn download_with_ytdlp(
     let output = Command::new("yt-dlp")
         .args([
             "--no-playlist",
-            "-f", "bestaudio[ext=m4a]/bestaudio[ext=mp4]/bestaudio",
-            "--merge-output-format", "mp4",
-            "-o", output_path.to_str().unwrap(),
+            "-f",
+            "bestaudio[ext=m4a]/bestaudio[ext=mp4]/bestaudio",
+            "--merge-output-format",
+            "mp4",
+            "-o",
+            output_path.to_str().unwrap(),
             "--no-progress",
             "--quiet",
             &url,
@@ -66,8 +71,9 @@ async fn download_with_ytdlp(
         .await?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(DownloadError::YtDlpFailed(stderr));
+        return Err(DownloadError::YtDlpFailed(
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+        ));
     }
 
     sender(DownloadManagerMessage::VideoStatusUpdate(
@@ -84,9 +90,9 @@ async fn download_with_rusty_ytdl(
     output_path: &std::path::Path,
     sender: &MessageHandler,
 ) -> Result<(), DownloadError> {
+    use rusty_ytdl::{DownloadOptions, Video, VideoOptions, VideoQuality, VideoSearchOptions};
     use std::io::Write;
     use std::sync::Arc;
-    use rusty_ytdl::{DownloadOptions, Video, VideoOptions, VideoQuality, VideoSearchOptions};
 
     let search_options = VideoSearchOptions::Custom(Arc::new(|format| {
         format.has_audio && !format.has_video && format.mime_type.container == "mp4"
@@ -149,11 +155,7 @@ async fn download_with_rusty_ytdl(
 }
 
 impl DownloadManager {
-    async fn handle_download(
-        &self,
-        id: &str,
-        sender: MessageHandler,
-    ) -> Result<(), DownloadError> {
+    async fn handle_download(&self, id: &str, sender: MessageHandler) -> Result<(), DownloadError> {
         let file = self.cache_dir.join("downloads").join(format!("{id}.mp4"));
         match self.downloader {
             Downloader::YtDlp => download_with_ytdlp(id, &file, &sender).await,
@@ -209,7 +211,7 @@ impl DownloadManager {
                     song.video_id.clone(),
                     MusicDownloadStatus::DownloadFailed,
                 ));
-                error!("Error downloading {}: {e}", song.video_id);
+                error!("couldn't download {}: {e}", song.video_id);
                 false
             }
         }

--- a/crates/download-manager/src/task.rs
+++ b/crates/download-manager/src/task.rs
@@ -4,12 +4,14 @@ use log::error;
 use tokio::process::Command;
 use ytpapi2::YoutubeMusicVideoRef;
 
-use crate::{DownloadManager, DownloadManagerMessage, MessageHandler, MusicDownloadStatus};
+use crate::{Downloader, DownloadManager, DownloadManagerMessage, MessageHandler, MusicDownloadStatus};
 
 #[derive(Debug)]
 pub enum DownloadError {
     YtDlpFailed(String),
     IoError(std::io::Error),
+    #[cfg(feature = "rusty-ytdl-backend")]
+    RustyYtdl(rusty_ytdl::VideoError),
 }
 
 impl std::fmt::Display for DownloadError {
@@ -17,6 +19,8 @@ impl std::fmt::Display for DownloadError {
         match self {
             DownloadError::YtDlpFailed(msg) => write!(f, "yt-dlp failed: {}", msg),
             DownloadError::IoError(e) => write!(f, "IO error: {}", e),
+            #[cfg(feature = "rusty-ytdl-backend")]
+            DownloadError::RustyYtdl(e) => write!(f, "rusty_ytdl error: {}", e),
         }
     }
 }
@@ -24,6 +28,13 @@ impl std::fmt::Display for DownloadError {
 impl From<std::io::Error> for DownloadError {
     fn from(e: std::io::Error) -> Self {
         DownloadError::IoError(e)
+    }
+}
+
+#[cfg(feature = "rusty-ytdl-backend")]
+impl From<rusty_ytdl::VideoError> for DownloadError {
+    fn from(e: rusty_ytdl::VideoError) -> Self {
+        DownloadError::RustyYtdl(e)
     }
 }
 
@@ -67,6 +78,76 @@ async fn download_with_ytdlp(
     Ok(())
 }
 
+#[cfg(feature = "rusty-ytdl-backend")]
+async fn download_with_rusty_ytdl(
+    video_id: &str,
+    output_path: &std::path::Path,
+    sender: &MessageHandler,
+) -> Result<(), DownloadError> {
+    use std::io::Write;
+    use std::sync::Arc;
+    use rusty_ytdl::{DownloadOptions, Video, VideoOptions, VideoQuality, VideoSearchOptions};
+
+    let search_options = VideoSearchOptions::Custom(Arc::new(|format| {
+        format.has_audio && !format.has_video && format.mime_type.container == "mp4"
+    }));
+    let video_options = VideoOptions {
+        quality: VideoQuality::Custom(
+            search_options.clone(),
+            Arc::new(|x, y| x.audio_bitrate.cmp(&y.audio_bitrate)),
+        ),
+        filter: search_options,
+        download_options: DownloadOptions {
+            dl_chunk_size: Some(1024 * 100_u64),
+        },
+        ..Default::default()
+    };
+
+    let video = Video::new_with_options(video_id, video_options)?;
+
+    sender(DownloadManagerMessage::VideoStatusUpdate(
+        video_id.to_string(),
+        MusicDownloadStatus::Downloading(0),
+    ));
+
+    let stream = video.stream().await?;
+    let length = stream.content_length();
+
+    let mut file = std::fs::File::create(output_path)
+        .map_err(|e| rusty_ytdl::VideoError::DownloadError(e.to_string()))?;
+
+    let mut total = 0;
+    while let Some(chunk) = stream.chunk().await? {
+        total += chunk.len();
+        sender(DownloadManagerMessage::VideoStatusUpdate(
+            video_id.to_string(),
+            MusicDownloadStatus::Downloading((total as f64 / length as f64 * 100.0) as usize),
+        ));
+        file.write_all(&chunk)
+            .map_err(|e| rusty_ytdl::VideoError::DownloadError(e.to_string()))?;
+    }
+
+    file.flush()
+        .map_err(|e| rusty_ytdl::VideoError::DownloadError(e.to_string()))?;
+
+    if total != length || length == 0 {
+        std::fs::remove_file(output_path)
+            .map_err(|e| rusty_ytdl::VideoError::DownloadError(e.to_string()))?;
+        return Err(rusty_ytdl::VideoError::DownloadError(format!(
+            "Downloaded file is not the same size as the content length ({}/{})",
+            total, length
+        ))
+        .into());
+    }
+
+    sender(DownloadManagerMessage::VideoStatusUpdate(
+        video_id.to_string(),
+        MusicDownloadStatus::Downloading(100),
+    ));
+
+    Ok(())
+}
+
 impl DownloadManager {
     async fn handle_download(
         &self,
@@ -74,7 +155,11 @@ impl DownloadManager {
         sender: MessageHandler,
     ) -> Result<(), DownloadError> {
         let file = self.cache_dir.join("downloads").join(format!("{id}.mp4"));
-        download_with_ytdlp(id, &file, &sender).await
+        match self.downloader {
+            Downloader::YtDlp => download_with_ytdlp(id, &file, &sender).await,
+            #[cfg(feature = "rusty-ytdl-backend")]
+            Downloader::RustyYtdl => download_with_rusty_ytdl(id, &file, &sender).await,
+        }
     }
 
     pub async fn start_download(&self, song: YoutubeMusicVideoRef, s: MessageHandler) -> bool {

--- a/crates/ytermusic/Cargo.toml
+++ b/crates/ytermusic/Cargo.toml
@@ -53,6 +53,9 @@ rookie = "0.5.2"
 
 ctrlc = "3.5.0"
 
+[features]
+rusty-ytdl-backend = ["download-manager/rusty-ytdl-backend"]
+
 [target."cfg(target_os = \"windows\")".dependencies]
 raw-window-handle = "0.4.3"
 winit = "0.26.1"

--- a/crates/ytermusic/src/config.rs
+++ b/crates/ytermusic/src/config.rs
@@ -21,7 +21,6 @@ pub struct GlobalConfig {
     /// Default value is 4.
     #[serde(default = "parallel_downloads")]
     pub parallel_downloads: u16,
-    /// Download backend. "ytdlp" (default) or "rusty_ytdl" (legacy).
     #[serde(default)]
     pub downloader: DownloaderConfig,
 }

--- a/crates/ytermusic/src/config.rs
+++ b/crates/ytermusic/src/config.rs
@@ -4,6 +4,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::utils::get_project_dirs;
 
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DownloaderConfig {
+    #[default]
+    Ytdlp,
+    RustyYtdl,
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GlobalConfig {
@@ -13,6 +21,9 @@ pub struct GlobalConfig {
     /// Default value is 4.
     #[serde(default = "parallel_downloads")]
     pub parallel_downloads: u16,
+    /// Download backend. "ytdlp" (default) or "rusty_ytdl" (legacy).
+    #[serde(default)]
+    pub downloader: DownloaderConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/ytermusic/src/main.rs
+++ b/crates/ytermusic/src/main.rs
@@ -218,14 +218,19 @@ async fn app_start_main(updater_r: Receiver<ManagerMessage>, updater_s: Sender<M
     std::fs::create_dir_all(CACHE_DIR.join("downloads")).unwrap();
 
     if CONFIG.global.downloader == crate::config::DownloaderConfig::Ytdlp {
-        match std::process::Command::new("yt-dlp").arg("--version").output() {
+        match std::process::Command::new("yt-dlp")
+            .arg("--version")
+            .output()
+        {
             Ok(out) if out.status.success() => {
-                info!("yt-dlp found: {}", String::from_utf8_lossy(&out.stdout).trim());
+                info!(
+                    "yt-dlp found: {}",
+                    String::from_utf8_lossy(&out.stdout).trim()
+                );
             }
             _ => {
-                println!("Error: yt-dlp not found in PATH.");
-                println!("Install it from https://github.com/yt-dlp/yt-dlp#installation");
-                println!("or set `downloader = \"rusty_ytdl\"` in your config to use the legacy backend.");
+                println!("yt-dlp not found in PATH");
+                println!("get it at https://github.com/yt-dlp/yt-dlp or set downloader = \"rusty_ytdl\" in config");
                 std::io::stdin().read_line(&mut String::new()).unwrap();
                 return;
             }

--- a/crates/ytermusic/src/main.rs
+++ b/crates/ytermusic/src/main.rs
@@ -1,4 +1,4 @@
-use consts::{CACHE_DIR, INTRODUCTION};
+use consts::{CACHE_DIR, CONFIG, INTRODUCTION};
 use flume::{Receiver, Sender};
 use log::{error, info};
 use once_cell::sync::Lazy;
@@ -216,6 +216,21 @@ async fn app_start_main(updater_r: Receiver<ManagerMessage>, updater_s: Sender<M
     STARTUP_TIME.log("Init");
 
     std::fs::create_dir_all(CACHE_DIR.join("downloads")).unwrap();
+
+    if CONFIG.global.downloader == crate::config::DownloaderConfig::Ytdlp {
+        match std::process::Command::new("yt-dlp").arg("--version").output() {
+            Ok(out) if out.status.success() => {
+                info!("yt-dlp found: {}", String::from_utf8_lossy(&out.stdout).trim());
+            }
+            _ => {
+                println!("Error: yt-dlp not found in PATH.");
+                println!("Install it from https://github.com/yt-dlp/yt-dlp#installation");
+                println!("or set `downloader = \"rusty_ytdl\"` in your config to use the legacy backend.");
+                std::io::stdin().read_line(&mut String::new()).unwrap();
+                return;
+            }
+        }
+    }
 
     if try_get_cookies().is_none() {
         if let Err((error, filepath)) = get_header_file() {

--- a/crates/ytermusic/src/systems/mod.rs
+++ b/crates/ytermusic/src/systems/mod.rs
@@ -1,4 +1,4 @@
-use download_manager::{Downloader, DownloadManager};
+use download_manager::{DownloadManager, Downloader};
 use once_cell::sync::Lazy;
 
 use crate::{
@@ -17,7 +17,7 @@ pub static DOWNLOAD_MANAGER: Lazy<DownloadManager> = Lazy::new(|| {
         DownloaderConfig::RustyYtdl => Downloader::RustyYtdl,
         #[cfg(not(feature = "rusty-ytdl-backend"))]
         DownloaderConfig::RustyYtdl => {
-            log::warn!("rusty-ytdl-backend feature not compiled in, falling back to yt-dlp");
+            log::warn!("rusty-ytdl-backend not compiled, using yt-dlp");
             Downloader::YtDlp
         }
     };

--- a/crates/ytermusic/src/systems/mod.rs
+++ b/crates/ytermusic/src/systems/mod.rs
@@ -1,7 +1,8 @@
-use download_manager::DownloadManager;
+use download_manager::{Downloader, DownloadManager};
 use once_cell::sync::Lazy;
 
 use crate::{
+    config::DownloaderConfig,
     consts::{CACHE_DIR, CONFIG},
     DATABASE,
 };
@@ -10,9 +11,20 @@ pub mod logger;
 pub mod player;
 
 pub static DOWNLOAD_MANAGER: Lazy<DownloadManager> = Lazy::new(|| {
+    let downloader = match CONFIG.global.downloader {
+        DownloaderConfig::Ytdlp => Downloader::YtDlp,
+        #[cfg(feature = "rusty-ytdl-backend")]
+        DownloaderConfig::RustyYtdl => Downloader::RustyYtdl,
+        #[cfg(not(feature = "rusty-ytdl-backend"))]
+        DownloaderConfig::RustyYtdl => {
+            log::warn!("rusty-ytdl-backend feature not compiled in, falling back to yt-dlp");
+            Downloader::YtDlp
+        }
+    };
     DownloadManager::new(
         CACHE_DIR.to_path_buf(),
         &DATABASE,
         CONFIG.global.parallel_downloads,
+        downloader,
     )
 });


### PR DESCRIPTION
rusty_ytdl uses the android youtube client to get stream urls and google blocked it, so every download 403s now. been broken for a while based on the issues

just replaced the download logic with a yt-dlp subprocess call. yt-dlp actually keeps up with whatever google changes so this shouldnt break again

yt-dlp is now a hard dep but it was basically already needed anyway. progress goes 0 -> 100 instead of incrementally since yt-dlp handles it internally, not a big deal

tested and working