### PR TITLE
fix: reduce idle CPU and thread usage

### DIFF
--- a/crates/download-manager/src/lib.rs
+++ b/crates/download-manager/src/lib.rs
@@ -4,11 +4,10 @@ use std::{
     collections::{HashSet, VecDeque},
     path::PathBuf,
     sync::{Arc, Mutex},
-    time::Duration,
 };
 
 use database::YTLocalDatabase;
-use tokio::{select, task::JoinHandle, time::sleep};
+use tokio::{select, sync::Notify, task::JoinHandle};
 use ytpapi2::YoutubeMusicVideoRef;
 
 use common_structs::MusicDownloadStatus;
@@ -34,6 +33,7 @@ pub struct DownloadManager {
     handles: Mutex<Vec<JoinHandle<()>>>,
     download_list: Mutex<VecDeque<YoutubeMusicVideoRef>>,
     in_download: Mutex<HashSet<String>>,
+    notify: Notify,
 }
 
 impl DownloadManager {
@@ -51,6 +51,7 @@ impl DownloadManager {
             handles: Mutex::new(Vec::new()),
             download_list: Mutex::new(VecDeque::new()),
             in_download: Mutex::new(HashSet::new()),
+            notify: Notify::new(),
         }
     }
 
@@ -76,7 +77,7 @@ impl DownloadManager {
                 if let Some(id) = self.take() {
                     self.start_download(id, sender.clone()).await;
                 } else {
-                    sleep(Duration::from_millis(200)).await;
+                    self.notify.notified().await;
                 }
             }
         };
@@ -120,10 +121,17 @@ impl DownloadManager {
         let mut list = self.download_list.lock().unwrap();
         list.clear();
         list.extend(to_add);
+        drop(list);
+        self.notify.notify_one();
     }
 
     pub fn add_to_download_list(&self, to_add: impl IntoIterator<Item = YoutubeMusicVideoRef>) {
         let mut list = self.download_list.lock().unwrap();
+        let was_empty = list.is_empty();
         list.extend(to_add);
+        drop(list);
+        if was_empty {
+            self.notify.notify_one();
+        }
     }
 }

--- a/crates/ytermusic/src/main.rs
+++ b/crates/ytermusic/src/main.rs
@@ -282,6 +282,7 @@ fn app_start() {
     .expect("Error setting Ctrl-C handler");
     std::thread::spawn(move || {
         tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
             .enable_all()
             .build()
             .expect("Failed to build runtime")

--- a/crates/ytermusic/src/shutdown.rs
+++ b/crates/ytermusic/src/shutdown.rs
@@ -2,12 +2,11 @@ use std::{
     future::Future,
     pin::Pin,
     sync::atomic::{AtomicBool, Ordering},
-    task::{Context, Poll},
+    sync::{Condvar, Mutex},
+    task::{Context, Poll, Waker},
 };
 
 use log::info;
-
-use std::sync::{Condvar, Mutex};
 
 pub struct SharedEvent {
     lock: Mutex<bool>,
@@ -48,6 +47,7 @@ pub fn block_until_shutdown() {
 }
 
 static SHUTDOWN_SENT: AtomicBool = AtomicBool::new(false);
+static WAKERS: Mutex<Vec<Waker>> = Mutex::new(Vec::new());
 
 pub fn is_shutdown_sent() -> bool {
     SHUTDOWN_SENT.load(Ordering::Relaxed)
@@ -59,10 +59,15 @@ pub struct ShutdownSignal;
 impl Future for ShutdownSignal {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if SHUTDOWN_SENT.load(Ordering::Relaxed) {
             Poll::Ready(())
         } else {
+            let waker = cx.waker().clone();
+            let mut wakers = WAKERS.lock().unwrap();
+            if !wakers.iter().any(|w| w.will_wake(&waker)) {
+                wakers.push(waker);
+            }
             Poll::Pending
         }
     }
@@ -70,6 +75,11 @@ impl Future for ShutdownSignal {
 
 pub fn shutdown() {
     SHUTDOWN_SENT.store(true, Ordering::Relaxed);
+    let mut wakers = WAKERS.lock().unwrap();
+    for waker in wakers.drain(..) {
+        waker.wake();
+    }
+    drop(wakers);
     SHUTDOWN_WAKER.notify();
     info!("Shutdown signal sent, waiting for shutdown");
 }

--- a/crates/ytermusic/src/structures/media.rs
+++ b/crates/ytermusic/src/structures/media.rs
@@ -211,6 +211,8 @@ pub fn run_window_handler(updater: &Sender<ManagerMessage>) -> Option<()> {
             info!("event loop closed");
             *ctrl_flow = winit::event_loop::ControlFlow::Exit;
             exit(0);
+        } else {
+            *ctrl_flow = winit::event_loop::ControlFlow::Wait;
         }
     });
 }

--- a/crates/ytermusic/src/systems/player.rs
+++ b/crates/ytermusic/src/systems/player.rs
@@ -32,6 +32,7 @@ pub struct PlayerState {
     pub soundaction_sender: Sender<SoundAction>,
     pub soundaction_receiver: Receiver<SoundAction>,
     pub stream_error_receiver: Receiver<PlayError>,
+    last_download_list: Vec<String>,
 }
 
 impl PlayerState {
@@ -63,6 +64,7 @@ impl PlayerState {
             list: Vec::new(),
             current: 0,
             rtcurrent: None,
+            last_download_list: Vec::new(),
         }
     }
 
@@ -175,7 +177,11 @@ impl PlayerState {
             .take(12)
             .cloned()
             .collect::<VecDeque<_>>();
-        DOWNLOAD_MANAGER.set_download_list(to_download);
+        let new_ids: Vec<String> = to_download.iter().map(|v| v.video_id.clone()).collect();
+        if new_ids != self.last_download_list {
+            self.last_download_list = new_ids;
+            DOWNLOAD_MANAGER.set_download_list(to_download);
+        }
     }
 
     fn handle_stream_errors(&self) {

--- a/crates/ytpapi2/src/lib.rs
+++ b/crates/ytpapi2/src/lib.rs
@@ -120,6 +120,7 @@ pub struct YoutubeMusicInstance {
     client_version: String,
     cookies: String,
     account_id: Option<String>,
+    client: reqwest::Client,
 }
 
 impl YoutubeMusicInstance {
@@ -229,6 +230,7 @@ impl YoutubeMusicInstance {
             client_version: client_version.to_string(),
             cookies,
             account_id,
+            client: rest_client,
         })
     }
     fn compute_sapi_hash(&self) -> String {
@@ -294,7 +296,7 @@ impl YoutubeMusicInstance {
                 self.client_version
             ),
         };
-        reqwest::Client::new()
+        self.client
             .post(&url)
             .header("Content-Type", "application/json")
             .header(
@@ -332,7 +334,7 @@ impl YoutubeMusicInstance {
                 self.client_version
             ),
         };
-        reqwest::Client::new()
+        self.client
             .post(&url)
             .header("Content-Type", "application/json")
             .header(


### PR DESCRIPTION
## Problem
On macOS (and likely other platforms), ytermusic consumes excessive CPU and spawns many threads even when idle and not playing music.

## Benchmark (idle, 10s sample)
| | Threads | Avg CPU | Peak CPU |
|---|---|---|---|
| Before | ~95 | 65% | 81% |
| After | ~15 | 0.7% | 0.9% |

## Changes
1. **winit event loop**: set `ControlFlow::Wait` on macOS. The default in winit 0.26.1 is `Poll`, which causes the event loop to spin at 100% on one core.
2. **tokio runtime**: capped `worker_threads` to 2. The default multi-thread scheduler spawns `num_cpus` workers (8-16 on modern Macs), which is overkill for a TUI music app.
3. **ShutdownSignal**: fixed broken waker registration. The future was returning `Pending` without storing the waker, causing tokio to busy-poll it.
4. **ytpapi2 client reuse**: moved `reqwest::Client` into `YoutubeMusicInstance`. Previously a new client was created per request, losing connection pooling and spawning extra threads.
5. **Download manager**: replaced the `sleep(200ms)` polling loop with `tokio::sync::Notify`. Workers now sleep until work actually arrives.
6. **Player dedup**: `set_download_list` was called every UI tick, clearing and re-adding the queue. Now it only updates when the video ID list actually changes.

## Testing
- `cargo build --release` passes.
- Ran 10-second idle benchmark comparing original vs patched binaries.
