### PR TITLE
fix: prevent crash when pressing 'r' on empty playlist

### DIFF
--- a/crates/ytermusic/src/structures/sound_action.rs
+++ b/crates/ytermusic/src/structures/sound_action.rs
@@ -125,6 +125,9 @@ impl SoundAction {
                 }
             }
             Self::DeleteVideoUnary => {
+                if player.list.is_empty() {
+                    return;
+                }
                 let index_list = player.list_selector.get_relative_position();
                 let video = player.relative_current(index_list).cloned().unwrap();
                 if matches!(
@@ -166,6 +169,9 @@ impl SoundAction {
                 }
             }
             Self::ReplaceQueue(videos) => {
+                if videos.is_empty() {
+                    return;
+                }
                 player.list.truncate(player.current + 1);
                 DOWNLOAD_MANAGER.clean(
                     ShutdownSignal,


### PR DESCRIPTION
## Issue

   When the playlist is empty and user presses 'r', the app crashes with:

    panicked at sound_action.rs:129:74

   ## Reproduction

   1. Launch ytermusic
   2. Go to music player screen
   3. Ensure playlist is empty
   4. Press 'r' key
   5. App crashes

   ## Root Cause

   DeleteVideoUnary action (bound to 'r') calls:

       let video = player.relative_current(index_list).cloned().unwrap();

   When playlist is empty, relative_current() returns None, causing unwrap()
 to panic.

   ## Fix

   Add guard clause in DeleteVideoUnary:

       if player.list.is_empty() {
           return;
       }

   Also add guard in ReplaceQueue for empty videos list (found during
 analysis).

   ## Changes

   File: crates/ytermusic/src/structures/sound_action.rs

   1. DeleteVideoUnary: Added empty playlist check
   2. ReplaceQueue: Added empty videos check