### PR TITLE
Cache maganement at startup

### DIFF
--- a/crates/ytermusic/src/cache_manager.rs
+++ b/crates/ytermusic/src/cache_manager.rs
@@ -1,0 +1,193 @@
+// TODO : Task cache management that needs to:
+//          - limit further downloads if cache limit is attained
+//          - delete previous cached songs that were already played
+//          - not delete the played song (optionnaly the next song)
+//        TEST with shuffle functionality
+//        TEST with low cache size
+//        TEST with large playlists (download limiter)
+
+use log::{info, warn};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+use std::{fs, future};
+use ytpapi2::YoutubeMusicVideoRef;
+
+use crate::config::DeletingPolicy;
+use crate::consts::CACHE_DIR;
+use crate::consts::CONFIG;
+use crate::DATABASE;
+
+/// Parse a size string like "500MB" or "2GB" into bytes.
+/// Returns None if the string is invalid or no limit specified.
+pub fn parse_size_to_bytes(size_str: String) -> Option<u64> {
+    let size_str = size_str.trim().to_uppercase();
+
+    if size_str.ends_with("MB") {
+        let num_str = size_str.trim_end_matches("MB").trim();
+        if let Ok(num) = num_str.parse::<u64>() {
+            return Some(num * 1024 * 1024);
+        }
+    }
+    if size_str.ends_with("GB") {
+        let num_str = size_str.trim_end_matches("GB").trim();
+        if let Ok(num) = num_str.parse::<u64>() {
+            return Some(num * 1024 * 1024 * 1024);
+        }
+    }
+    if size_str == "" {
+        return Some(0);
+    }
+    None
+}
+
+/// get file time in function of the deleting policy
+fn get_file_time(path: &Path) -> Option<SystemTime> {
+    let metadata = fs::metadata(path).ok()?;
+
+    let file_time = match CONFIG.cache.deleting_policy {
+        DeletingPolicy::Mtime => metadata.modified().ok()?,
+        DeletingPolicy::Atime => metadata.accessed().ok()?,
+        DeletingPolicy::Ctime => metadata.created().ok()?,
+    };
+
+    Some(file_time)
+}
+
+/// Returns a vector of (path, file_time) tuples sorted by "acces" time (newest first).
+fn get_time_sorted_files(downloads_dir: &Path) -> Vec<(PathBuf, SystemTime)> {
+    let mut files_with_time: Vec<(PathBuf, SystemTime)> = Vec::new();
+
+    if !downloads_dir.exists() || !downloads_dir.is_dir() {
+        return files_with_time;
+    }
+
+    for entry in fs::read_dir(downloads_dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_file() && path.extension().unwrap() == "mp4" {
+            match get_file_time(&path) {
+                Some(time) => files_with_time.push((path, time)),
+                None => files_with_time.push((path, SystemTime::UNIX_EPOCH)), // needs win testing
+            };
+        }
+    }
+    files_with_time.sort_by_key(|(_, time)| *time);
+    files_with_time.reverse();
+    files_with_time
+}
+
+/// Calculate the total size of all files in the downloads directory.
+pub fn get_cache_size(downloads_dir: &Path) -> u64 {
+    let mut total_size: u64 = 0;
+
+    if !downloads_dir.exists() || !downloads_dir.is_dir() {
+        return 0;
+    }
+
+    for entry in fs::read_dir(downloads_dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_file() && path.extension().unwrap() == "mp4" {
+            // json sizes are negligible compared to mp4s
+            total_size += path.metadata().unwrap().len();
+        }
+    }
+
+    total_size
+}
+
+/// Format bytes into a human-readable string.
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} bytes", bytes)
+    }
+}
+
+/// Enforce the cache limit by deleting the least accessed files on startup
+pub fn startup_cache_limit() {
+    let downloads_dir = CACHE_DIR.join("downloads");
+
+    let max_size_bytes = match parse_size_to_bytes(CONFIG.cache.max_size.clone()) {
+        Some(size) => size,
+        None => {
+            warn!("Invalid cache size format, please check your config file");
+            return;
+        }
+    };
+
+    if max_size_bytes == 0 {
+        return; // 0MB or 0GB means no cache limit
+    }
+
+    let mut current_size = get_cache_size(&downloads_dir);
+
+    info!(
+        "Current cache size: {}, Limit: {}",
+        format_bytes(current_size),
+        format_bytes(max_size_bytes)
+    );
+
+    if current_size <= max_size_bytes {
+        return;
+    }
+
+    let mut files_with_date = get_time_sorted_files(&downloads_dir);
+
+    while current_size > max_size_bytes {
+        if let Some((file_path, _)) = files_with_date.pop() {
+            let file_size = fs::metadata(&file_path).map(|m| m.len()).unwrap_or(0);
+            let video_id = file_path
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .map(|s| s.to_string())
+                .unwrap();
+            let json_path = file_path.with_extension("json");
+
+            match fs::remove_file(&file_path) {
+                Err(e) => {
+                    warn!(
+                        "Failed to delete mp4'{}': {}",
+                        file_path.file_name().unwrap_or_default().display(),
+                        e
+                    );
+                }
+                Ok(_) => {
+                    let video = YoutubeMusicVideoRef {
+                        title: String::default(),
+                        author: String::default(),
+                        album: String::default(),
+                        video_id,
+                        duration: String::default(),
+                    }; // we only need the video id
+                    let _ = fs::remove_file(&json_path); // remove json if it exists
+                    info!(
+                        "Deleted cached song '{}' to enforce cache limit (freed {})",
+                        file_path.file_name().unwrap_or_default().display(),
+                        format_bytes(file_size)
+                    );
+                    current_size -= file_size;
+                }
+            }
+        } else {
+            break;
+        }
+    }
+    DATABASE.fix_db();
+    info!(
+        "Cache cleanup complete. New cache size: {}",
+        format_bytes(current_size)
+    );
+}
+
+/// Initialize cache management on startup.
+pub fn init_cache_management() {
+    startup_cache_limit();
+}

--- a/crates/ytermusic/src/cache_utils.rs
+++ b/crates/ytermusic/src/cache_utils.rs
@@ -30,7 +30,7 @@ pub fn parse_size_to_bytes(size_str: String) -> Option<u64> {
             return Some(num * 1024 * 1024 * 1024);
         }
     }
-    if size_str == "" {
+    if size_str.is_empty() {
         return Some(0);
     }
     None

--- a/crates/ytermusic/src/cache_utils.rs
+++ b/crates/ytermusic/src/cache_utils.rs
@@ -6,16 +6,12 @@
 //        TEST with low cache size
 //        TEST with large playlists (download limiter)
 
-use log::{info, warn};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
-use std::{fs, future};
-use ytpapi2::YoutubeMusicVideoRef;
 
 use crate::config::DeletingPolicy;
-use crate::consts::CACHE_DIR;
 use crate::consts::CONFIG;
-use crate::DATABASE;
 
 /// Parse a size string like "500MB" or "2GB" into bytes.
 /// Returns None if the string is invalid or no limit specified.
@@ -41,7 +37,7 @@ pub fn parse_size_to_bytes(size_str: String) -> Option<u64> {
 }
 
 /// get file time in function of the deleting policy
-fn get_file_time(path: &Path) -> Option<SystemTime> {
+pub fn get_file_time(path: &Path) -> Option<SystemTime> {
     let metadata = fs::metadata(path).ok()?;
 
     let file_time = match CONFIG.cache.deleting_policy {
@@ -54,7 +50,7 @@ fn get_file_time(path: &Path) -> Option<SystemTime> {
 }
 
 /// Returns a vector of (path, file_time) tuples sorted by "acces" time (newest first).
-fn get_time_sorted_files(downloads_dir: &Path) -> Vec<(PathBuf, SystemTime)> {
+pub fn get_time_sorted_files(downloads_dir: &Path) -> Vec<(PathBuf, SystemTime)> {
     let mut files_with_time: Vec<(PathBuf, SystemTime)> = Vec::new();
 
     if !downloads_dir.exists() || !downloads_dir.is_dir() {
@@ -95,7 +91,7 @@ pub fn get_cache_size(downloads_dir: &Path) -> u64 {
 }
 
 /// Format bytes into a human-readable string.
-fn format_bytes(bytes: u64) -> String {
+pub fn format_bytes(bytes: u64) -> String {
     const KB: u64 = 1024;
     const MB: u64 = KB * 1024;
     const GB: u64 = MB * 1024;
@@ -109,85 +105,4 @@ fn format_bytes(bytes: u64) -> String {
     } else {
         format!("{} bytes", bytes)
     }
-}
-
-/// Enforce the cache limit by deleting the least accessed files on startup
-pub fn startup_cache_limit() {
-    let downloads_dir = CACHE_DIR.join("downloads");
-
-    let max_size_bytes = match parse_size_to_bytes(CONFIG.cache.max_size.clone()) {
-        Some(size) => size,
-        None => {
-            warn!("Invalid cache size format, please check your config file");
-            return;
-        }
-    };
-
-    if max_size_bytes == 0 {
-        return; // 0MB or 0GB means no cache limit
-    }
-
-    let mut current_size = get_cache_size(&downloads_dir);
-
-    info!(
-        "Current cache size: {}, Limit: {}",
-        format_bytes(current_size),
-        format_bytes(max_size_bytes)
-    );
-
-    if current_size <= max_size_bytes {
-        return;
-    }
-
-    let mut files_with_date = get_time_sorted_files(&downloads_dir);
-
-    while current_size > max_size_bytes {
-        if let Some((file_path, _)) = files_with_date.pop() {
-            let file_size = fs::metadata(&file_path).map(|m| m.len()).unwrap_or(0);
-            let video_id = file_path
-                .file_stem()
-                .and_then(|name| name.to_str())
-                .map(|s| s.to_string())
-                .unwrap();
-            let json_path = file_path.with_extension("json");
-
-            match fs::remove_file(&file_path) {
-                Err(e) => {
-                    warn!(
-                        "Failed to delete mp4'{}': {}",
-                        file_path.file_name().unwrap_or_default().display(),
-                        e
-                    );
-                }
-                Ok(_) => {
-                    let video = YoutubeMusicVideoRef {
-                        title: String::default(),
-                        author: String::default(),
-                        album: String::default(),
-                        video_id,
-                        duration: String::default(),
-                    }; // we only need the video id
-                    let _ = fs::remove_file(&json_path); // remove json if it exists
-                    info!(
-                        "Deleted cached song '{}' to enforce cache limit (freed {})",
-                        file_path.file_name().unwrap_or_default().display(),
-                        format_bytes(file_size)
-                    );
-                    current_size -= file_size;
-                }
-            }
-        } else {
-            break;
-        }
-    }
-    DATABASE.fix_db();
-    info!(
-        "Cache cleanup complete. New cache size: {}",
-        format_bytes(current_size)
-    );
-}
-
-/// Initialize cache management on startup.
-pub fn init_cache_management() {
-    startup_cache_limit();
 }

--- a/crates/ytermusic/src/config.rs
+++ b/crates/ytermusic/src/config.rs
@@ -12,6 +12,15 @@ pub enum DownloaderConfig {
     RustyYtdl,
 }
 
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeletingPolicy {
+    #[default]
+    Mtime,
+    Atime, // We could need to update the acces time each time we play a new song for better following
+    Ctime,
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GlobalConfig {
@@ -23,6 +32,20 @@ pub struct GlobalConfig {
     pub parallel_downloads: u16,
     #[serde(default)]
     pub downloader: DownloaderConfig,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct CacheConfig {
+    /// Maximum cache size. Use format like "500MB" or "2GB".
+    /// Empty string or wrongly formatted means unlimited.
+    #[serde(default = "default_max_size")]
+    pub max_size: String,
+    /// Oldest? Least accessed?
+    /// Modified time (Mtime) as default because it's more robust than creation date (Ctime).
+    /// For most OS default configs, the acces time (Atime) is unreliable or disabled for performance reasons.
+    #[serde(default)]
+    pub deleting_policy: DeletingPolicy,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -147,6 +170,10 @@ fn default_volume() -> u8 {
     50
 }
 
+fn default_max_size() -> String {
+    String::from("0MB")
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PlaylistConfig {}
@@ -161,6 +188,8 @@ pub struct SearchConfig {}
 pub struct Config {
     #[serde(default)]
     pub global: GlobalConfig,
+    #[serde(default)]
+    pub cache: CacheConfig,
     #[serde(default)]
     pub player: MusicPlayerConfig,
     #[serde(default)]

--- a/crates/ytermusic/src/main.rs
+++ b/crates/ytermusic/src/main.rs
@@ -22,6 +22,7 @@ use crate::{
     utils::get_project_dirs,
 };
 
+mod cache_manager;
 mod config;
 mod consts;
 mod database;
@@ -127,6 +128,8 @@ fn main() {
         error!("{e}");
         shutdown();
     }));
+    // Enforce cache limit on startup
+    cache_manager::init_cache_management();
     app_start();
 }
 

--- a/crates/ytermusic/src/main.rs
+++ b/crates/ytermusic/src/main.rs
@@ -22,7 +22,7 @@ use crate::{
     utils::get_project_dirs,
 };
 
-mod cache_manager;
+mod cache_utils;
 mod config;
 mod consts;
 mod database;
@@ -128,8 +128,6 @@ fn main() {
         error!("{e}");
         shutdown();
     }));
-    // Enforce cache limit on startup
-    cache_manager::init_cache_management();
     app_start();
 }
 
@@ -255,8 +253,11 @@ async fn app_start_main(updater_r: Receiver<ManagerMessage>, updater_s: Sender<M
 
     // Spawn the clean task
     tasks::clean::spawn_clean_task();
-
     STARTUP_TIME.log("Spawned clean task");
+
+    tasks::cache_init::spawn_cache_task();
+    STARTUP_TIME.log("Spawned cache task");
+
     // Spawn the player task
     let (sa, player) = player_system(updater_s.clone());
     // Spawn the downloader system

--- a/crates/ytermusic/src/tasks/cache_init.rs
+++ b/crates/ytermusic/src/tasks/cache_init.rs
@@ -1,0 +1,78 @@
+use crate::{
+    cache_utils,
+    consts::{CACHE_DIR, CONFIG},
+    run_service,
+    structures::performance,
+    DATABASE,
+};
+use log::{info, warn};
+use std::fs;
+
+/// Enforce the cache limit by deleting the least accessed files on startup
+pub fn spawn_cache_task() {
+    run_service(async move {
+        let guard = performance::guard("Cache task");
+        let downloads_dir = CACHE_DIR.join("downloads");
+
+        let max_size_bytes = match cache_utils::parse_size_to_bytes(CONFIG.cache.max_size.clone()) {
+            Some(size) => size,
+            None => {
+                warn!("Invalid cache size format, please check your config file");
+                return;
+            }
+        };
+
+        if max_size_bytes == 0 {
+            return; // 0MB or 0GB means no cache limit
+        }
+
+        let mut current_size = cache_utils::get_cache_size(&downloads_dir);
+
+        info!(
+            "Current cache size: {}, Limit: {}",
+            cache_utils::format_bytes(current_size),
+            cache_utils::format_bytes(max_size_bytes)
+        );
+
+        if current_size <= max_size_bytes {
+            return;
+        }
+
+        let mut files_with_date = cache_utils::get_time_sorted_files(&downloads_dir);
+
+        while current_size > max_size_bytes {
+            if let Some((file_path, _)) = files_with_date.pop() {
+                let file_size = fs::metadata(&file_path).map(|m| m.len()).unwrap_or(0);
+                let json_path = file_path.with_extension("json");
+
+                match fs::remove_file(&file_path) {
+                    Err(e) => {
+                        warn!(
+                            "Failed to delete mp4'{}': {}",
+                            file_path.file_name().unwrap_or_default().display(),
+                            e
+                        );
+                    }
+                    Ok(_) => {
+                        let _ = fs::remove_file(&json_path); // remove json if it exists
+                        info!(
+                            "Deleted cached song '{}' to enforce cache limit (freed {})",
+                            file_path.file_name().unwrap_or_default().display(),
+                            cache_utils::format_bytes(file_size)
+                        );
+                        current_size -= file_size;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        DATABASE.fix_db();
+        DATABASE.write();
+        info!(
+            "Cache cleanup complete. New cache size: {}",
+            cache_utils::format_bytes(current_size)
+        );
+        drop(guard);
+    });
+}

--- a/crates/ytermusic/src/tasks/mod.rs
+++ b/crates/ytermusic/src/tasks/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod cache_init;
 pub mod clean;
 pub mod last_playlist;
 pub mod local_musics;


### PR DESCRIPTION
Hello,
I've begin working on some cache management.
It's a first try on doing it at startup, which is far easier to do it on-the-fly.
The PR works (at least with my tests) and can be merged, but I first wanted to discuss about the architecture.

What this PR does is:
+ a new `cache_utils` module with functions that will allow us to regroup evrything necessary for the cache management and future devloppements.
+ a new `cache_init` task for checking the cache size at stratup and deleting the older songs if the cache size is too big.
+ two new config parameters into a [Cache] section. The first is a maximum cache size `max_size` which can be left empty for an unlimited cache size or can be changed for a limit in MB or GB. The second is a deleting policy. It changes if we want to delete the oldest created file, the oldest acessed file or the oldest modified file. Modified ("mtime") by default, because acces times are rarely true on most OSes and created time changes on copy.


What I would want in order to complete the cache management is to do it during runtime, but after a litte fit of reflexion, it is much more complex. We at least need to:
- limit further downloads if cache limit is attained and reallow them after
- delete previous cached songs that were already played
- not delete the played song (optionnaly the next song)
- modify the database in function to track what's downloaded or not

Because it would require do to multiple checks on multiple different structs, I thought that doing a new module was the better solution.